### PR TITLE
remove Stale and Archived sensors from the query

### DIFF
--- a/cybereason/cybereason.py
+++ b/cybereason/cybereason.py
@@ -93,7 +93,11 @@ def query_sensor_by_ip(ip):
                 "fieldName": "internalIpAddress",
                 "operator": "Equals",
                 "values": [ip]
-
+            },
+	        {
+		        "fieldName": "status",
+                "operator": "NotEquals",
+                "values": ["Archived","Stale"]
             }
         ]
     }


### PR DESCRIPTION
When querying sensor by IP, exclude sensors with status Archived or Stale. 

When a sensor is archived, all information are kept, including the Internal IP. When querying that IP, it looks at sensors in any state (even archived sensor where the information is outdated) and if multiple results are returned. The script will not be able to assign the right tags to Detect UI. 